### PR TITLE
Fix import path for eris

### DIFF
--- a/Default-port-allocations.md
+++ b/Default-port-allocations.md
@@ -231,7 +231,7 @@ See https://prometheus.io/docs/instrumenting/writing_exporters/#port-numbers for
 | 9311 | [IOTA Exporter](https://github.com/crholliday/iota-prom-exporter) |
 | 9312 | UNALLOCATED (to avoid collision with Sphinx search API) |
 | 9313 | [Cloudprober Exporter](https://github.com/google/cloudprober) |
-| 9314 | [eris Exporter](https://github.com/prologic/eris) |
+| 9314 | [eris Exporter](https://git.mills.io/prologic/eris) |
 | 9315 | [Centrifugo Exporter](https://github.com/nordicdyno/centrifugo_exporter) |
 | 9316 | [Tado Exporter](https://github.com/exporters/tado) |
 | 9317 | [Tellstick Local Exporter](https://github.com/hoihrig/prometheus-tellstick-exporter) |


### PR DESCRIPTION
Project has moved to [git.mills.io/prologic/eris](https://git.mills.io/prologic/eris).

For details on why see: https://github.com/prologic

Thank you! 🙇